### PR TITLE
chore: Update CLA link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,5 +53,5 @@ In order for us to review and merge your code, please follow the link and sign t
 [create pr]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [GitHub hub]: https://hub.github.com
 [ssh key]: https://help.github.com/articles/generating-ssh-keys
-[CLA]: https://simpleclub.page.link/cla
+[CLA]: https://cla-assistant.io/simpleclub/
 [versioning]: https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338


### PR DESCRIPTION
## Description

We had to update the link after migrating the CLA tool: https://simpleclub.slack.com/archives/CATPELDMH/p1736153833672199?thread_ts=1733313483.185789&cid=CATPELDMH
supersedes https://github.com/simpleclub/design_tokens_builder/pull/15
## Related issues & PRs

[SC-14984]

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [ ] I added a PR description.
- [ ] I linked all related issues and PRs I could find (no links if there are none).
- [ ] If this PR changes anything about the main `design_tokens_builder` package
  (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
  on its own is not worth an update).
- [ ] If this PR includes a notable change in the `design_token_builder` package, I updated the version
  according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [ ] If there is new functionality in code, I added tests covering all my additions.
- [ ] All required checks pass.

[SC-14984]: https://simpleclub.atlassian.net/browse/SC-14984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ