### PR TITLE
Parse percentage values with decimal part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UPCOMING RELEASE
+
+* Add support for decimal percentage values.
+
 ## 0.2.0+1
 
 * Improve package documentation.

--- a/lib/factory/token_set_factory.dart
+++ b/lib/factory/token_set_factory.dart
@@ -177,9 +177,9 @@ dynamic _parseAttribute(
 /// Returns `null` if parsing failed.
 double parsePercentage(dynamic value) {
   if (value is String) {
-    final abs = int.tryParse(
-      value.split('%').first,
-    );
+    final numberPart = value.split('%').first;
+    final abs = int.tryParse(numberPart) ?? double.tryParse(numberPart);
+
     if (abs != null) {
       return abs / 100;
     }

--- a/test/factory/token_set_factory_test.dart
+++ b/test/factory/token_set_factory_test.dart
@@ -7,11 +7,17 @@ void main() {
     test('succeeds with %', () {
       final result = parsePercentage('420%');
       expect(result, 4.2);
+
+      final result1 = parsePercentage('694.2%');
+      expect(result1, closeTo(6.942, 0.001));
     });
 
     test('succeeds without %', () {
       final result = parsePercentage('69');
       expect(result, 0.69);
+
+      final result1 = parsePercentage('69.42');
+      expect(result1, closeTo(0.6942, 0.0001));
     });
 
     test('fails', () {


### PR DESCRIPTION
## Description

The change introduced here makes percentage values to also be allowed to have a decimal part.

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I added a PR description.
- [x] If this PR changes anything about the main `design_tokens_builder` package
  (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
  on its own is not worth an update).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.